### PR TITLE
Side collision and Top Collision working (almost)

### DIFF
--- a/GAME211_StudentTemplate/PlayerBody.cpp
+++ b/GAME211_StudentTemplate/PlayerBody.cpp
@@ -221,15 +221,9 @@ bool PlayerBody::HasCollidedSide(SDL_Rect rect)
     wallTouchLeft = false;
     wallTouchRight = false;
 
-    // Small tolerance for collision accuracy
-    const int tolerance = 1; 
-
     // First, check if there is a general collision
-    if ((pos.x - radius) > (rect.x + rect.w ) || ((pos.x + radius) < (rect.x )) ||  // x positions with tolerance
-        ((pos.y + radius) < (rect.y - rect.h )) || ((pos.y - radius) > (rect.y )))  // y positions with tolerance
-    {
-       //std::cout << " no collision " << std::endl;
-        return false;  // No collision
+    if (!HasCollidedWith(rect)) {
+        return false;
     }
 
     // Calculate overlaps on all sides
@@ -257,6 +251,32 @@ bool PlayerBody::HasCollidedSide(SDL_Rect rect)
             wallTouchLeft = true;
 
         }
+        return true;  // Side collision occurred
+    }
+    return false;
+}
+
+bool PlayerBody::HasCollidedTop(SDL_Rect rect)
+{
+    // First, check if there is a general collision
+    if (!HasCollidedWith(rect)) {
+        return false;
+    }
+
+    // Calculate overlaps on all sides
+    float overlapRight = (rect.x + rect.w) - (pos.x - radius);  // Overlap on left side
+    float overlapLeft = (pos.x + radius) - rect.x;  // Overlap on right side
+    float overlapTop = (rect.y + rect.h) - (pos.y - radius);  // Overlap on top side
+    float overlapBottom = (pos.y + radius) - rect.y;  // Overlap on bottom side
+
+    // Determine the smallest overlap (side or top/bottom)
+    float minHorizontalOverlap = std::min(overlapLeft, overlapRight);
+    float minVerticalOverlap = std::min(overlapTop, overlapBottom);
+
+    // If horizontal overlap is smaller, it's a side collision
+    std::cout << "minHorizontalOverlap: " << minHorizontalOverlap << " minVerticalOverlap: " << minVerticalOverlap << std::endl;
+    if (minVerticalOverlap > 0.9) {
+        
         return true;  // Side collision occurred
     }
     return false;

--- a/GAME211_StudentTemplate/PlayerBody.h
+++ b/GAME211_StudentTemplate/PlayerBody.h
@@ -65,6 +65,7 @@ public:
     void ApplyForce(Vec3 force); // added for calculating force on player (Maya)
     bool HasCollidedWith(SDL_Rect rect); // added for calculating collision (Maya)
     bool HasCollidedSide(SDL_Rect rect);
+    bool HasCollidedTop(SDL_Rect rect);
     
 };
 

--- a/GAME211_StudentTemplate/Scene1.cpp
+++ b/GAME211_StudentTemplate/Scene1.cpp
@@ -80,30 +80,34 @@ void Scene1::Update(const float deltaTime) {
 	//loop through platforms
 	for (const SDL_Rect& build : builds) {
 		if (game->getPlayer()->HasCollidedSide(build)) {
-			std::cout << "Side collision " << std::endl;
-			Vec3 currentAccel = game->getPlayer()->getAccel();
-			Vec3 currentVel = game->getPlayer()->getVel();
-			game->getPlayer()->setAccel(Vec3(0.0f, currentAccel.y, currentAccel.z));
-			game->getPlayer()->setVel(Vec3(0.0f, currentAccel.y, currentVel.z));
-		}
-		//Check Collision
-		if (game->getPlayer()->HasCollidedWith(build)) {
-			//get the accel and vel of player and set the accel and vel to the current accel and vel other than y make it 0 to stop y motion when colliding
-			
-			Vec3 currentAccel = game->getPlayer()->getAccel();
-			Vec3 currentVel = game->getPlayer()->getVel();
-			game->getPlayer()->setAccel(Vec3(currentAccel.x, 0.0f, currentAccel.z));
-			game->getPlayer()->setVel(Vec3(currentVel.x, 0.0f, currentVel.z));
-			game->getPlayer()->isGrounded = true; //set isGrounded to true
 
-			break;
+				std::cout << "Side collision " << std::endl;
+				Vec3 currentAccel = game->getPlayer()->getAccel();
+				Vec3 currentVel = game->getPlayer()->getVel();
+				game->getPlayer()->setAccel(Vec3(0.0f, currentAccel.y, currentAccel.z));
+				game->getPlayer()->setVel(Vec3(0.0f, currentAccel.y, currentVel.z));
+			
+		}
+			//Check Collision
+		if (game->getPlayer()->HasCollidedTop(build)) {
+				//get the accel and vel of player and set the accel and vel to the current accel and vel other than y make it 0 to stop y motion when colliding
+
+				Vec3 currentAccel = game->getPlayer()->getAccel();
+				Vec3 currentVel = game->getPlayer()->getVel();
+				game->getPlayer()->setAccel(Vec3(currentAccel.x, 0.0f, currentAccel.z));
+				game->getPlayer()->setVel(Vec3(currentVel.x, 0.0f, currentVel.z));
+				game->getPlayer()->isGrounded = true; //set isGrounded to true
+
+				break;
 		}
 
 		else {
-			
+
 			game->getPlayer()->isGrounded = false; //if you aren't colliding set is grounded to false
 
 		}
+		
+		
 	}
 }
 


### PR DESCRIPTION
The player can now collide with the side of a platform and slide down it, not getting stuck while they fall while still being able to collide with the top of a platform. Separating the collision into two checks allows it to work smoother. Now, we just need to figure out how to make it check if it's colliding with multiple platforms at the same time, if a wall is overlapping with a platform, it does not currently check collision. This is the next issue we need to fix